### PR TITLE
Type error for countryNameEn in index.d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,7 @@ declare module 'country-codes-list' {
   ): string[];
 
   export function customList(
-    key?: CountryProperty,
+    key?: CountryProperty | string,
     label?: string,
     settings?: CustomArraySettings,
   ): { [CountryProperty]: string };


### PR DESCRIPTION
Argument of type '"countryNameEn"' is not assignable to parameter of type 'CountryProperty | undefined'. Adding key?: CountryProperty | string to line 57 made it work seamless.